### PR TITLE
Add feature to read only a slice of a dataset in C++.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 data/*
+build/*

--- a/erg/erg.h
+++ b/erg/erg.h
@@ -147,7 +147,7 @@ public:
     std::string unit;   //!< The unit. It can be an empty string.
     std::string typeStr; //!< The type represented as string.
     Type type;          //!< The type.
-    size_t size;        //!< The size in bytes.
+    size_t size;        //!< The size in bytes of each data element.
     size_t offset;      //!< The offset in bytes from the start of the record.
 };
 
@@ -239,11 +239,23 @@ public:
      * \brief Read a single dataset from the file
      *
      * \param qindex Index of the dataset to read
-     * \param outData The pre-allocated destination memory
+     * \param dst The pre-allocated destination memory
      * \param size The size of the allocated memory
      * \return The number of records that has been read.
      */
-    size_t read(const size_t qindex, uint8_t* outData, const size_t size);
+    size_t read(const size_t qindex, uint8_t* dst, const size_t size);
+
+    /*!
+     * \brief Read a slice of single dataset from the file
+     *
+     * \param qindex Index of the dataset to read
+     * \param from Index of the first record to read
+     * \param count Maximum number of records to read
+     * \param dst The pre-allocated destination memory
+     * \param size The size of the allocated memory
+     * \return The number of records that has been read.
+     */
+    size_t read(const size_t qindex, const size_t from, const size_t count, uint8_t* dst, const size_t size);
 
     /*!
      * \brief Size in bytes of the dataset at the current index.

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -269,13 +269,23 @@ TEST(Reader, Read)
 
     std::vector<double> Time(parser.records(), 0.0);
     size_t timeIndex = parser.index("Data_8");
-    size_t numRows = parser.read(timeIndex, reinterpret_cast<uint8_t*>(Time.data()), Time.size());
+    size_t numRows = parser.read(timeIndex, reinterpret_cast<uint8_t*>(Time.data()), Time.size()*sizeof(double));
     ASSERT_EQ(numRows, parser.records());
 
     for(int i=0; i<numRows; ++i)
     {
         int value = std::lround(Time[i]*100.0);
         ASSERT_EQ(value, i);
+    }
+
+    std::vector<double> Time2(100, 0.0);
+    numRows = parser.read(timeIndex, 1000, 100, reinterpret_cast<uint8_t*>(Time2.data()), Time2.size()*sizeof(double));
+    ASSERT_EQ(numRows, 100);
+
+    for(int i=0; i<numRows; ++i)
+    {
+        int value = std::lround(Time2[i]*100.0);
+        ASSERT_EQ(value, i+1000);
     }
 }
 


### PR DESCRIPTION
Fixed bug in `erg::Reader::read()` function: wrong check of the size of the destination data.
